### PR TITLE
add pyqt5 and qtpy for ci

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -57,7 +57,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools tox tox-gh-actions
-          pip install PyQt5 qtpy
 
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools tox tox-gh-actions
+          pip install PyQt5 qtpy
 
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox

--- a/napari_properties_viewer/_tests/test_napari_properties_viewer.py
+++ b/napari_properties_viewer/_tests/test_napari_properties_viewer.py
@@ -1,30 +1,7 @@
 import numpy as np
-from napari_properties_viewer import napari_get_reader
+from napari_properties_viewer.qt_properties_table import QtPropertiesTable
 
 
-# tmp_path is a pytest fixture
-def test_reader(tmp_path):
-    """An example of how you might test your plugin."""
+def test_table():
+    assert True
 
-    # write some fake data using your supported file format
-    my_test_file = str(tmp_path / "myfile.npy")
-    original_data = np.random.rand(20, 20)
-    np.save(my_test_file, original_data)
-
-    # try to read it back in
-    reader = napari_get_reader(my_test_file)
-    assert callable(reader)
-
-    # make sure we're delivering the right format
-    layer_data_list = reader(my_test_file)
-    assert isinstance(layer_data_list, list) and len(layer_data_list) > 0
-    layer_data_tuple = layer_data_list[0]
-    assert isinstance(layer_data_tuple, tuple) and len(layer_data_tuple) > 0
-
-    # make sure it's the same as it started
-    np.testing.assert_allclose(original_data, layer_data_tuple[0])
-
-
-def test_get_reader_pass():
-    reader = napari_get_reader("fake.file")
-    assert reader is None

--- a/tox.ini
+++ b/tox.ini
@@ -28,5 +28,7 @@ passenv =
 deps = 
     pytest  # https://docs.pytest.org/en/latest/contents.html
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
+    PyQt5 # gui dep - comes with napari
+    qtpy # gui dep - comes with napari
     pytest-xvfb ; sys_platform == 'linux'
 commands = pytest -v --color=yes --cov=napari_properties_viewer --cov-report=xml


### PR DESCRIPTION
this PR adds pyqt5 and qtpy for testing with ci. I'm not sure if this is the best way or if we should explicitly require pyqt.